### PR TITLE
Add raw html support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Render Pandoc documents in reflex-dom.
 
-Not all parts of the Pandoc AST are handled; the following in particular needs to be done:
+Nearly all parts of the AST are rendered, except the following:
 
 - [ ] Table is rendered only in basic fashion; but its attributes are not handled.
 - [ ] `Citation` (Pandoc's `Cite` node)
-- [ ] Raw blocks and inlines

--- a/reflex-dom-pandoc.cabal
+++ b/reflex-dom-pandoc.cabal
@@ -19,6 +19,8 @@ source-repository head
 
 library
   exposed-modules:
+      Reflex.Dom.Pandoc
+      Reflex.Dom.Pandoc.PandocRaw
       Reflex.Dom.Pandoc.Document
     , Reflex.Dom.Pandoc.SyntaxHighlighting
   other-modules:

--- a/reflex-dom-pandoc.cabal
+++ b/reflex-dom-pandoc.cabal
@@ -44,5 +44,7 @@ library
     , skylighting
     , text
     , time
+    , ref-tf
+    , reflex
   default-language: Haskell2010
 

--- a/reflex-dom-pandoc.cabal
+++ b/reflex-dom-pandoc.cabal
@@ -46,5 +46,6 @@ library
     , time
     , ref-tf
     , reflex
+    , constraints
   default-language: Haskell2010
 

--- a/src/Reflex/Dom/Pandoc.hs
+++ b/src/Reflex/Dom/Pandoc.hs
@@ -1,0 +1,7 @@
+module Reflex.Dom.Pandoc
+  ( module X,
+  )
+where
+
+import Reflex.Dom.Pandoc.Document as X
+import Reflex.Dom.Pandoc.PandocRaw as X

--- a/src/Reflex/Dom/Pandoc/Document.hs
+++ b/src/Reflex/Dom/Pandoc/Document.hs
@@ -16,8 +16,9 @@ module Reflex.Dom.Pandoc.Document
   ( elPandocDoc,
     elPandocInlines,
     elPandocHeading1,
-    rawAsActual,
     rawAsRaw,
+    PandocBuilder,
+    RawHtml (..),
   )
 where
 
@@ -41,7 +42,7 @@ import Text.Pandoc.Definition
 
 class RawHtml m where
   type RawHtmlConstraints m :: Constraint
-  elRawHtml :: RawHtmlConstraints m => Text -> m ()
+  elRawHtml :: RawHtmlConstraints m => Format -> Text -> m ()
 
 instance RawHtml (StaticDomBuilderT t m) where
   type
@@ -57,86 +58,90 @@ instance RawHtml (StaticDomBuilderT t m) where
         PerformEvent t m,
         MonadReflexCreateTrigger t m
       )
-  elRawHtml :: RawHtmlConstraints (StaticDomBuilderT t m) => Text -> StaticDomBuilderT t m ()
-  elRawHtml s =
+  elRawHtml _f s =
     StaticDomBuilderT $ lift $ modify $ (:) $ fmap encodeUtf8Builder $ current $ constDyn s
 
-elPandocInlinesStatic ::
-  forall t m.
-  (RawHtmlConstraints (StaticDomBuilderT t m)) =>
-  [Inline] ->
-  StaticDomBuilderT t m ()
-elPandocInlinesStatic = void . flip runReaderT mempty . renderInlines (lift . (\(Format s) -> elRawHtml s))
+instance RawHtml m => RawHtml (ReaderT a m) where
+  type RawHtmlConstraints (ReaderT a m) = RawHtmlConstraints m
+  elRawHtml f s = ReaderT $ \_ -> elRawHtml f s
+
+instance RawHtml m => RawHtml (PostBuildT t m) where
+  type RawHtmlConstraints (PostBuildT t m) = RawHtmlConstraints m
+  elRawHtml f s = PostBuildT $ ReaderT $ \_ ->
+    elRawHtml f s
+
+type PandocBuilder t m =
+  ( DomBuilder t m,
+    RawHtml m,
+    RawHtmlConstraints m
+  )
 
 -- | Render list of Pandoc inlines
-elPandocInlines :: forall t m. DomBuilder t m => [Inline] -> m ()
-elPandocInlines = void . sansFootnotes . renderInlines rawAsRaw
+elPandocInlines :: forall t m. PandocBuilder t m => [Inline] -> m ()
+elPandocInlines = void . sansFootnotes . renderInlines
 
-type RenderRawF t m = DomBuilder t m => Format -> m ()
+type RenderRawF t m = PandocBuilder t m => Format -> Text -> m ()
 
 rawAsRaw :: RenderRawF t m
-rawAsRaw (Format s) =
-  el "pre" $ text s
+rawAsRaw (Format f) s =
+  elClass "pre" ("pandoc-raw " <> f) $ text s
 
-rawAsActual :: (Reflex t, Monad m) => Format -> StaticDomBuilderT t m ()
-rawAsActual (Format s) =
-  StaticDomBuilderT $ lift $ modify $ (:) $ fmap encodeUtf8Builder $ current $ constDyn s
-
-renderBlocks :: (MonadReader Footnotes m, DomBuilder t m) => (RenderRawF t m) -> [Block] -> m ()
-renderBlocks renderRaw =
-  mapM_ $ renderBlock renderRaw
+renderBlocks :: (MonadReader Footnotes m, PandocBuilder t m) => [Block] -> m ()
+renderBlocks =
+  mapM_ $ renderBlock
 
 -- | Convert Markdown to HTML
-elPandocDoc :: forall t m. DomBuilder t m => (RenderRawF t m) -> Pandoc -> m ()
-elPandocDoc renderRaw doc@(Pandoc _meta blocks) = do
+elPandocDoc :: forall t m. PandocBuilder t m => Pandoc -> m ()
+elPandocDoc doc@(Pandoc _meta blocks) = do
   let fs = getFootnotes doc
-  flip runReaderT fs $ renderBlocks (lift . renderRaw) blocks
-  renderFootnotes (sansFootnotes . renderBlocks (lift . renderRaw)) fs
+  flip runReaderT fs $ renderBlocks blocks
+  renderFootnotes (sansFootnotes . renderBlocks) fs
 
 -- | Render the first level of heading
-elPandocHeading1 :: DomBuilder t m => Pandoc -> m ()
+elPandocHeading1 :: PandocBuilder t m => Pandoc -> m ()
 elPandocHeading1 (Pandoc _meta blocks) = forM_ blocks $ \case
   Header 1 _ xs -> elPandocInlines xs
   _ -> blank
 
-renderBlock :: (MonadReader Footnotes m, DomBuilder t m) => (RenderRawF t m) -> Block -> m ()
-renderBlock renderRaw = \case
+renderBlock :: (MonadReader Footnotes m, PandocBuilder t m) => Block -> m ()
+renderBlock = \case
   -- Pandoc parses github tasklist as this structure.
-  Plain (Str "☐" : Space : is) -> checkboxEl False >> renderInlines renderRaw is
-  Plain (Str "☒" : Space : is) -> checkboxEl True >> renderInlines renderRaw is
-  Para (Str "☐" : Space : is) -> checkboxEl False >> renderInlines renderRaw is
-  Para (Str "☒" : Space : is) -> checkboxEl True >> renderInlines renderRaw is
+  Plain (Str "☐" : Space : is) -> checkboxEl False >> renderInlines is
+  Plain (Str "☒" : Space : is) -> checkboxEl True >> renderInlines is
+  Para (Str "☐" : Space : is) -> checkboxEl False >> renderInlines is
+  Para (Str "☒" : Space : is) -> checkboxEl True >> renderInlines is
   Plain xs ->
-    renderInlines renderRaw xs
+    renderInlines xs
   Para xs ->
-    el "p" $ renderInlines renderRaw xs
+    el "p" $ renderInlines xs
   LineBlock xss ->
     forM_ xss $ \xs -> do
-      renderInlines renderRaw xs <* text "\n"
+      renderInlines xs <* text "\n"
   CodeBlock attr x ->
     elCodeHighlighted attr x
-  RawBlock (Format t) x ->
+  RawBlock fmt x ->
     -- We are not *yet* sure what to do with this. For now, just dump it in pre.
     -- NOTE: if t==html, we must embed the raw HTML. But this doesn't seem
     -- possible reflex-dom without ghcjs constraints.
-    elClass "pre" ("pandoc-raw " <> t) $ text x
+    -- elClass "pre" ("pandoc-raw " <> t) $ text x
+    elRawHtml fmt x
   BlockQuote xs ->
-    el "blockquote" $ renderBlocks renderRaw xs
+    el "blockquote" $ renderBlocks xs
   OrderedList _lattr xss ->
     -- TODO: Implement list attributes.
     el "ol" $ do
       forM_ xss $ \xs -> do
-        el "li" $ renderBlocks renderRaw xs
+        el "li" $ renderBlocks xs
   BulletList xss ->
-    el "ul" $ forM_ xss $ \xs -> el "li" $ renderBlocks renderRaw xs
+    el "ul" $ forM_ xss $ \xs -> el "li" $ renderBlocks xs
   DefinitionList defs ->
     el "dl" $ forM_ defs $ \(term, descList) -> do
-      el "dt" $ renderInlines renderRaw term
+      el "dt" $ renderInlines term
       forM_ descList $ \desc ->
-        el "dd" $ renderBlocks renderRaw desc
+        el "dd" $ renderBlocks desc
   Header level attr xs ->
     elPandocAttr (headerElement level) attr $ do
-      renderInlines renderRaw xs
+      renderInlines xs
   HorizontalRule ->
     el "hr" blank
   Table _attr _captions _colSpec (TableHead _ hrows) tbodys _tfoot -> do
@@ -146,16 +151,16 @@ renderBlock renderRaw = \case
         forM_ hrows $ \(Row _ cells) -> do
           el "tr" $ do
             forM_ cells $ \(Cell _ _ _ _ blks) ->
-              el "th" $ renderBlocks renderRaw blks
+              el "th" $ renderBlocks blks
       forM_ tbodys $ \(TableBody _ _ _ rows) ->
         el "tbody" $ do
           forM_ rows $ \(Row _ cells) ->
             el "tr" $ do
               forM_ cells $ \(Cell _ _ _ _ blks) ->
-                el "td" $ renderBlocks renderRaw blks
+                el "td" $ renderBlocks blks
   Div attr xs ->
     elPandocAttr "div" attr $
-      renderBlocks renderRaw xs
+      renderBlocks xs
   Null ->
     blank
   where
@@ -171,30 +176,30 @@ renderBlock renderRaw = \case
           )
           blank
 
-renderInlines :: (MonadReader Footnotes m, DomBuilder t m) => (RenderRawF t m) -> [Inline] -> m ()
-renderInlines renderRaw =
-  mapM_ $ renderInline renderRaw
+renderInlines :: (MonadReader Footnotes m, PandocBuilder t m) => [Inline] -> m ()
+renderInlines =
+  mapM_ $ renderInline
 
-renderInline :: (MonadReader Footnotes m, DomBuilder t m) => (RenderRawF t m) -> Inline -> m ()
-renderInline renderRaw = \case
+renderInline :: (MonadReader Footnotes m, PandocBuilder t m) => Inline -> m ()
+renderInline = \case
   Str x ->
     text x
   Emph xs ->
-    el "em" $ renderInlines renderRaw xs
+    el "em" $ renderInlines xs
   Strong xs ->
-    el "strong" $ renderInlines renderRaw xs
+    el "strong" $ renderInlines xs
   Underline xs ->
-    el "u" $ renderInlines renderRaw xs
+    el "u" $ renderInlines xs
   Strikeout xs ->
-    el "strike" $ renderInlines renderRaw xs
+    el "strike" $ renderInlines xs
   Superscript xs ->
-    el "sup" $ renderInlines renderRaw xs
+    el "sup" $ renderInlines xs
   Subscript xs ->
-    el "sub" $ renderInlines renderRaw xs
+    el "sub" $ renderInlines xs
   SmallCaps xs ->
-    el "small" $ renderInlines renderRaw xs
+    el "small" $ renderInlines xs
   Quoted qt xs ->
-    flip inQuotes qt $ renderInlines renderRaw xs
+    flip inQuotes qt $ renderInlines xs
   Cite _ _ ->
     el "pre" $ text "error[reflex-doc-pandoc]: Pandoc Cite is not handled"
   Code attr x ->
@@ -218,10 +223,10 @@ renderInline renderRaw = \case
         elClass "span" "math display" $ text "$$" >> text s >> text "$$"
   Link attr xs (lUrl, lTitle) -> do
     let attr' = renderAttr attr <> ("href" =: lUrl <> "title" =: lTitle)
-    elAttr "a" attr' $ renderInlines renderRaw xs
+    elAttr "a" attr' $ renderInlines xs
   Image attr xs (iUrl, iTitle) -> do
     let attr' = renderAttr attr <> ("src" =: iUrl <> "title" =: iTitle)
-    elAttr "img" attr' $ renderInlines renderRaw xs
+    elAttr "img" attr' $ renderInlines xs
   Note xs -> do
     fs :: Footnotes <- ask
     case Map.lookup (Footnote xs) fs of
@@ -229,13 +234,13 @@ renderInline renderRaw = \case
         -- No footnote in the global map (this means that the user has
         -- defined a footnote inside a footnote); just put the whole thing in
         -- aside.
-        elClass "aside" "footnote-inline" $ renderBlocks renderRaw xs
+        elClass "aside" "footnote-inline" $ renderBlocks xs
       Just idx ->
         renderFootnoteRef idx
   -- el "aside" $ renderBlocks xs
   Span attr xs ->
     elPandocAttr "span" attr $
-      renderInlines renderRaw xs
+      renderInlines xs
   where
     inQuotes w = \case
       SingleQuote -> text "❛" >> w <* text "❜"

--- a/src/Reflex/Dom/Pandoc/Document.hs
+++ b/src/Reflex/Dom/Pandoc/Document.hs
@@ -120,10 +120,6 @@ renderBlock = \case
   CodeBlock attr x ->
     elCodeHighlighted attr x
   RawBlock fmt x ->
-    -- We are not *yet* sure what to do with this. For now, just dump it in pre.
-    -- NOTE: if t==html, we must embed the raw HTML. But this doesn't seem
-    -- possible reflex-dom without ghcjs constraints.
-    -- elClass "pre" ("pandoc-raw " <> t) $ text x
     elRawHtml fmt x
   BlockQuote xs ->
     el "blockquote" $ renderBlocks xs
@@ -211,9 +207,8 @@ renderInline = \case
     text " "
   LineBreak ->
     text "\n"
-  RawInline _ x ->
-    -- See comment in RawBlock above
-    el "code" $ text x
+  RawInline fmt x ->
+    elRawHtml fmt x
   Math mathType s ->
     -- http://docs.mathjax.org/en/latest/basic/mathematics.html#tex-and-latex-input
     case mathType of

--- a/src/Reflex/Dom/Pandoc/PandocRaw.hs
+++ b/src/Reflex/Dom/Pandoc/PandocRaw.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Reflex.Dom.Pandoc.PandocRaw
+  ( PandocRaw (..),
+    elPandocRawSafe,
+  )
+where
+
+import Control.Monad.Fix (MonadFix)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Reader (ReaderT (..), lift)
+import Control.Monad.Ref (MonadRef, Ref)
+import Control.Monad.State (modify)
+import Data.Constraint
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8Builder)
+import GHC.IORef
+import Reflex.Dom.Core hiding (Link, Space)
+import Reflex.Host.Class
+import Text.Pandoc.Definition
+
+-- | Class to define how to render pandoc raw nodes
+class PandocRaw m where
+  -- | The constraints required to render
+  type PandocRawConstraints m :: Constraint
+
+  -- | Render a raw content of the given format
+  -- TODO: Distinguish between inline vs block
+  elPandocRaw :: PandocRawConstraints m => Format -> Text -> m ()
+
+-- | In a static builder, we accept whatever raw html that comes through.
+instance PandocRaw (StaticDomBuilderT t m) where
+  type
+    PandocRawConstraints (StaticDomBuilderT t m) =
+      ( Reflex t,
+        Monad m,
+        Ref m ~ IORef,
+        MonadIO m,
+        MonadHold t m,
+        MonadFix m,
+        MonadRef m,
+        Adjustable t m,
+        PerformEvent t m,
+        MonadReflexCreateTrigger t m
+      )
+  elPandocRaw f@(Format format) s =
+    case format of
+      x
+        | x `elem` ["html", "html4", "html5"] ->
+          StaticDomBuilderT $ lift $ modify $ (:) $ fmap encodeUtf8Builder $ current $ constDyn s
+      _ ->
+        elPandocRawSafe f s
+
+elPandocRawSafe :: DomBuilder t m => Format -> Text -> m ()
+elPandocRawSafe (Format format) s =
+  elClass "pre" ("pandoc-raw " <> format) $ text s
+
+instance PandocRaw m => PandocRaw (ReaderT a m) where
+  type PandocRawConstraints (ReaderT a m) = PandocRawConstraints m
+  elPandocRaw f s = ReaderT $ \_ -> elPandocRaw f s
+
+instance PandocRaw m => PandocRaw (PostBuildT t m) where
+  type PandocRawConstraints (PostBuildT t m) = PandocRawConstraints m
+  elPandocRaw f s = PostBuildT $ ReaderT $ \_ ->
+    elPandocRaw f s


### PR DESCRIPTION
`StaticDomBuilderT` (which is used by `renderStatic`) will automatically inject the raw html as-is. However, in other cases, it is highly recommended to simply disable the raw html. For example:

![image](https://user-images.githubusercontent.com/3998/82078702-961abf80-96af-11ea-953c-cd45d3bd375c.png)
 
## Todo

- [x] Raw inline
- [x] Refactor
- [x] Rename `RawHtml` to `RawContent`? Because pandoc allows [formats other than HTML](https://pandoc.org/MANUAL.html#generic-raw-attribute).