### PR TITLE
Add hie.yaml file

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,4 @@
+cradle:
+  cabal:
+    - path: "src"
+      component: "lib:reflex-dom-pandoc"


### PR DESCRIPTION
File was generated with implicit-hie. For some reason, the haskell-language-server setup wasn't picking things up quite right for me without this file.