### PR TITLE
Prune empty attributes

### DIFF
--- a/src/Reflex/Dom/Pandoc/Document.hs
+++ b/src/Reflex/Dom/Pandoc/Document.hs
@@ -28,7 +28,6 @@ import Control.Monad
 import Control.Monad.Reader
 import Data.Bool
 import qualified Data.Map as Map
-import Data.Maybe
 import qualified Data.Text as T
 import Data.Traversable (for)
 import Reflex.Dom.Core hiding (Link, Space, mapAccum)
@@ -36,7 +35,7 @@ import Reflex.Dom.Pandoc.Footnotes
 import Reflex.Dom.Pandoc.PandocRaw
 import Reflex.Dom.Pandoc.SyntaxHighlighting (elCodeHighlighted)
 import Reflex.Dom.Pandoc.URILink
-import Reflex.Dom.Pandoc.Util (elPandocAttr, headerElement, memptyIfTrue, renderAttr)
+import Reflex.Dom.Pandoc.Util (elPandocAttr, headerElement, sansEmptyAttrs, renderAttr)
 import Text.Pandoc.Definition
 
 -- | Like `DomBuilder` but with a capability to render pandoc raw content.
@@ -206,7 +205,7 @@ renderInline cfg = \case
     pure mempty
   inline@(Link attr xs (lUrl, lTitle)) -> do
     let defaultRender = do
-          let attr' = renderAttr attr <> ("href" =: lUrl <> title lTitle)
+          let attr' = sansEmptyAttrs $ renderAttr attr <> ("href" =: lUrl <> "title" =: lTitle)
           elAttr "a" attr' $ renderInlines cfg xs
     case uriLinkFromInline inline of
       Just uriLink -> do
@@ -215,7 +214,7 @@ renderInline cfg = \case
       Nothing ->
         defaultRender
   Image attr xs (iUrl, iTitle) -> do
-    let attr' = renderAttr attr <> ("src" =: iUrl <> title iTitle)
+    let attr' = sansEmptyAttrs $ renderAttr attr <> ("src" =: iUrl <> "title" =: iTitle)
     elAttr "img" attr' $ renderInlines cfg xs
   Note xs -> do
     fs :: Footnotes <- ask
@@ -232,7 +231,6 @@ renderInline cfg = \case
     elPandocAttr "span" attr $
       renderInlines cfg xs
   where
-    title t = memptyIfTrue (T.null t) ("title" =: t)
     inQuotes w = \case
       SingleQuote -> text "‘" >> w <* text "’"
       DoubleQuote -> text "“" >> w <* text "”"

--- a/src/Reflex/Dom/Pandoc/Util.hs
+++ b/src/Reflex/Dom/Pandoc/Util.hs
@@ -20,14 +20,20 @@ elPandocAttr ::
   m a
 elPandocAttr name = elAttr name . renderAttr
 
+-- | memptyIfTrue p m = if p then mempty else m
+memptyIfTrue :: Monoid m => Bool -> m -> m
+memptyIfTrue p m = if p then mempty else m
+{-# INLINE memptyIfTrue #-}
+
 renderAttr ::
   -- | Pandoc attribute object. TODO: Use a sensible type.
   Attr ->
   Map Text Text
 renderAttr (identifier, classes, attrs) =
-  "id" =: identifier
-    <> "class" =: (T.unwords classes)
-    <> Map.fromList attrs
+  Map.filter (not . T.null) $
+    "id" =: identifier
+      <> "class" =: T.unwords classes
+      <> Map.fromList attrs
 
 addClass ::
   -- | The class to add

--- a/src/Reflex/Dom/Pandoc/Util.hs
+++ b/src/Reflex/Dom/Pandoc/Util.hs
@@ -18,22 +18,19 @@ elPandocAttr ::
   -- | Child widget
   m a ->
   m a
-elPandocAttr name = elAttr name . renderAttr
+elPandocAttr name = elAttr name . sansEmptyAttrs . renderAttr
 
--- | memptyIfTrue p m = if p then mempty else m
-memptyIfTrue :: Monoid m => Bool -> m -> m
-memptyIfTrue p m = if p then mempty else m
-{-# INLINE memptyIfTrue #-}
+sansEmptyAttrs :: Map k Text -> Map k Text
+sansEmptyAttrs = Map.filter (not . T.null)
 
 renderAttr ::
   -- | Pandoc attribute object. TODO: Use a sensible type.
   Attr ->
   Map Text Text
 renderAttr (identifier, classes, attrs) =
-  Map.filter (not . T.null) $
-    "id" =: identifier
-      <> "class" =: T.unwords classes
-      <> Map.fromList attrs
+  "id" =: identifier
+    <> "class" =: T.unwords classes
+    <> Map.fromList attrs
 
 addClass ::
   -- | The class to add


### PR DESCRIPTION
Prunes empty attributes from most everywhere in the codebase. I think it's still possible to end up with empty attributes in manual html generation, but I couldn't find much low hanging fruit where empty attributes were likely to be generated. (As it is, this gets every empty attribute that I could find in the `./guide` in srid/neuron)