### PR TITLE
Support fancy lists (ordered list attributes)

### DIFF
--- a/src/Reflex/Dom/Pandoc/Document.hs
+++ b/src/Reflex/Dom/Pandoc/Document.hs
@@ -29,7 +29,7 @@ import Control.Monad.Reader
 import Data.Bool
 import qualified Data.Map as Map
 import Data.Maybe
-import qualified Data.Text as T (pack)
+import qualified Data.Text as T
 import Data.Traversable (for)
 import Reflex.Dom.Core hiding (Link, Space, mapAccum)
 import Reflex.Dom.Pandoc.Footnotes


### PR DESCRIPTION
I tried to separate this PR out and #6 so they would merge cleanly regardless of order of application. I think I got it right this time...

This enables full support for [fancy lists](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/fancy_lists.md) in neuron (on the backend). Requires the [identically named PR](https://github.com/srid/neuron/pull/335) in srid/neuron in order to actually activate this codepath; otherwise `commonmark-hs` won't parse the markdown into the correct AST.