### PR TITLE
Render img element alt attribute

### DIFF
--- a/src/Reflex/Dom/Pandoc/Document.hs
+++ b/src/Reflex/Dom/Pandoc/Document.hs
@@ -224,9 +224,9 @@ renderInline cfg = \case
         (flip runReaderT fns defaultRender)
         lUrl
         minner
-  Image attr xs (iUrl, iTitle) -> do
-    let attr' = sansEmptyAttrs $ renderAttr attr <> ("src" =: iUrl <> "title" =: iTitle)
-    elAttr "img" attr' $ renderInlines cfg xs
+  Image attr xs target -> do
+    let attr' = imageAttrs attr xs target
+    elAttr "img" attr' blank >> pure mempty
   Note xs -> do
     fs :: Footnotes <- ask
     case Map.lookup (mkFootnote xs) fs of
@@ -244,3 +244,31 @@ renderInline cfg = \case
     inQuotes w = \case
       SingleQuote -> text "‘" >> w <* text "’"
       DoubleQuote -> text "“" >> w <* text "”"
+
+    -- Img alt text is represented as [Inline]
+    imageAttrs attr xs (iUrl, iTitle) =
+      sansEmptyAttrs $ renderAttr attr <> ("src" =: iUrl <> "title" =: iTitle <> "alt" =: inlinesToAlt xs)
+
+    inlinesToAlt = T.concat . map inlineToText
+
+    inlineToText = \case
+      Str t -> t
+      Emph xs -> inlinesToAlt xs
+      Underline xs -> inlinesToAlt xs
+      Strong xs -> inlinesToAlt xs
+      Strikeout xs -> inlinesToAlt xs
+      Subscript xs -> inlinesToAlt xs
+      SmallCaps xs -> inlinesToAlt xs
+      Quoted _ xs -> inlinesToAlt xs
+      Cite _ xs -> inlinesToAlt xs
+      Code _ t -> t
+      Space -> " "
+      SoftBreak -> " "
+      LineBreak -> " "
+      Math _ t -> t
+      RawInline _ t -> t
+      Link _ xs _ -> inlinesToAlt xs
+      Image _ xs _ -> inlinesToAlt xs
+      Note _ -> ""
+      Span _ xs -> inlinesToAlt xs
+      _ -> ""


### PR DESCRIPTION
Fixes Neuron's #434

The PR builds the `alt` attribute from the provided `Inline` list and adds it to the attributes of the `img` element. I've taken a rather permissive approach to `Inline`'s various values, preserving the purely textual content.

Since `img` is an empty element, I also replaced the call to `renderInlines` with `blank >> pure mempty`.